### PR TITLE
Add components for each destination

### DIFF
--- a/src/lib/components/DestinationCard.svelte
+++ b/src/lib/components/DestinationCard.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	interface Props {
+		title: string;
+		goal: string;
+		routes: string[];
+	}
+
+	const { title, goal, routes }: Props = $props();
+</script>
+
+<div
+	class="mb-4 rounded-lg border-l-4 border-blue-500 bg-gray-50 p-4 shadow-md transition-shadow hover:shadow-lg"
+>
+	<h2 class="mb-2 text-xl font-bold">{title}</h2>
+	<p class="mb-3 text-sm text-gray-700 italic">{goal}</p>
+
+	<div class="space-y-2">
+		{#each routes as route (route)}
+			<div class="flex items-start">
+				<div class="w-full rounded bg-white p-2 shadow-sm">
+					{route}
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/destinations/Church.svelte
+++ b/src/lib/components/destinations/Church.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { transit }: DistancesResult['church'] = $props();
+</script>
+
+<DestinationCard
+	title="Church ⛪️ "
+	goal="Ideally within 30 minutes (low priority)"
+	routes={[`🚇 ${transit.timeMinutes} minutes on the ${transit.summary}`]}
+/>

--- a/src/lib/components/destinations/FarmersMarket.svelte
+++ b/src/lib/components/destinations/FarmersMarket.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { closest, walk }: DistancesResult['farmersMarket'] = $props();
+</script>
+
+<DestinationCard
+	title="Farmers market 🍉"
+	goal="Ideally within a 15-minute walk (low priority)"
+	routes={[`🚶 ${walk.timeMinutes} minutes to ${closest.name} (${walk.distanceMiles} miles)`]}
+/>

--- a/src/lib/components/destinations/Fractal.svelte
+++ b/src/lib/components/destinations/Fractal.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { transit }: DistancesResult['fractal'] = $props();
+</script>
+
+<DestinationCard
+	title="Fractal 🪩"
+	goal="Ideally within 30 minutes (low priority)"
+	routes={[`🚇 ${transit.timeMinutes} minutes on the ${transit.summary}`]}
+/>

--- a/src/lib/components/destinations/Park.svelte
+++ b/src/lib/components/destinations/Park.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { closest, walk }: DistancesResult['park'] = $props();
+</script>
+
+<DestinationCard
+	title="Park 🌳"
+	goal="Must be within a 15-minute walk"
+	routes={[`🚶 ${walk.timeMinutes} minutes to ${closest.name} (${walk.distanceMiles} miles)`]}
+/>

--- a/src/lib/components/destinations/Partner.svelte
+++ b/src/lib/components/destinations/Partner.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { transit }: DistancesResult['partner'] = $props();
+</script>
+
+<DestinationCard
+	title="Partner 👬"
+	goal="Must be within 30 minutes; ideally within 20 minutes"
+	routes={[`🚇 ${transit.timeMinutes} minutes on the ${transit.summary}`]}
+/>

--- a/src/lib/components/destinations/SubwayStop.svelte
+++ b/src/lib/components/destinations/SubwayStop.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { closest, walk }: DistancesResult['subwayStop'] = $props();
+</script>
+
+<DestinationCard
+	title="Subway stop 🚇"
+	goal="Must be within a 12-minute walk; ideally within 7 minutes"
+	routes={[
+		`🚶 ${walk.timeMinutes} minutes to ${closest.name} with ${closest.lines.join(', ')} (${walk.distanceMiles} miles)`
+	]}
+/>

--- a/src/lib/components/destinations/Work.svelte
+++ b/src/lib/components/destinations/Work.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import DestinationCard from '$lib/components/DestinationCard.svelte';
+	import type { DistancesResult } from '$lib/types';
+
+	let { walk, bike }: DistancesResult['work'] = $props();
+</script>
+
+<DestinationCard
+	title="Work 👨🏼‍💻"
+	goal="Must be within 15 minutes by bike or walking; ideally within 10 minutes"
+	routes={[
+		`🚶 ${walk.timeMinutes} minutes (${walk.distanceMiles} miles)`,
+		`🚴 ${bike.timeMinutes} minutes (${bike.distanceMiles} miles)`
+	]}
+/>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,20 @@
 <script lang="ts">
+	import Church from '$lib/components/destinations/Church.svelte';
+	import FarmersMarket from '$lib/components/destinations/FarmersMarket.svelte';
+	import Fractal from '$lib/components/destinations/Fractal.svelte';
+	import Park from '$lib/components/destinations/Park.svelte';
+	import Partner from '$lib/components/destinations/Partner.svelte';
+	import SubwayStop from '$lib/components/destinations/SubwayStop.svelte';
+	import Work from '$lib/components/destinations/Work.svelte';
 	let { data } = $props();
 </script>
 
 <h1>NYC apartment distances</h1>
-<h2>Work</h2>
-<p>Walk: {data.distances.work.walk.timeMinutes} minutes</p>
-<p>Bike: {data.distances.work.bike.timeMinutes} minutes</p>
+
+<Work {...data.distances.work} />
+<Partner {...data.distances.partner} />
+<SubwayStop {...data.distances.subwayStop} />
+<Park {...data.distances.park} />
+<FarmersMarket {...data.distances.farmersMarket} />
+<Fractal {...data.distances.fractal} />
+<Church {...data.distances.church} />


### PR DESCRIPTION
This adds a basic (Claude-styled) component `DestinationCard`. This is not the final design, and it still is missing the `goalStatus` and color coding. But this gets the overall frontend code setup so I want to land it as a checkpoint.

Note that I intentionally don't DRY the `routes` because there is enough divergence that I think having a helper function would make things more confusing, like more indirection.