### PR TITLE
Wire up address submission to travel times state

### DIFF
--- a/src/lib/components/address/Address.svelte
+++ b/src/lib/components/address/Address.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import travelTimesState from '$lib/state/travelTimes.svelte';
+	import travelTimesRequest, { getTravelTimes } from '$lib/state/travelTimes.svelte';
 	import Card from '../Card.svelte';
 	import { isValidAddress } from './addressUtils.js';
 
@@ -16,9 +16,11 @@
 			/>
 		</div>
 		<div>
+			<!-- TODO: disabled should not allow multiple promises -->
 			<button
 				class="w-full cursor-pointer rounded-md bg-blue-600 px-4 py-2 font-medium text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-blue-400 disabled:opacity-50 disabled:hover:bg-blue-400 sm:w-auto"
-				disabled={!isValidAddress(address) || travelTimesState.status === 'loading'}
+				disabled={!isValidAddress(address)}
+				onclick={() => (travelTimesRequest.task = getTravelTimes())}
 			>
 				Calculate travel times
 			</button>

--- a/src/lib/components/address/Address.svelte
+++ b/src/lib/components/address/Address.svelte
@@ -4,6 +4,15 @@
 	import { isValidAddress } from './addressUtils.js';
 
 	let address = $state('');
+	let isRequestInFlight = $state(false);
+
+	function handleClick() {
+		if (isRequestInFlight) return;
+		isRequestInFlight = true;
+		travelTimesRequest.task = getTravelTimes().finally(() => {
+			isRequestInFlight = false;
+		});
+	}
 </script>
 
 <Card title="Street address">
@@ -16,11 +25,10 @@
 			/>
 		</div>
 		<div>
-			<!-- TODO: disabled should not allow multiple promises -->
 			<button
 				class="w-full cursor-pointer rounded-md bg-blue-600 px-4 py-2 font-medium text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-blue-400 disabled:opacity-50 disabled:hover:bg-blue-400 sm:w-auto"
-				disabled={!isValidAddress(address)}
-				onclick={() => (travelTimesRequest.task = getTravelTimes())}
+				disabled={!isValidAddress(address) || isRequestInFlight}
+				onclick={handleClick}
 			>
 				Calculate travel times
 			</button>

--- a/src/lib/components/travelTimes/TravelTimes.svelte
+++ b/src/lib/components/travelTimes/TravelTimes.svelte
@@ -3,17 +3,17 @@
 	import Loading from './Loading.svelte';
 	import Error from './Error.svelte';
 	import Success from './Success.svelte';
-	import travelTimesState from '$lib/state/travelTimes.svelte';
+	import travelTimesRequest from '$lib/state/travelTimes.svelte';
 </script>
 
-{#if travelTimesState.status !== 'unset'}
+{#if travelTimesRequest.task}
 	<Card title="Travel times">
-		{#if travelTimesState.status === 'loading'}
+		{#await travelTimesRequest.task}
 			<Loading />
-		{:else if travelTimesState.status === 'success'}
-			<Success {...travelTimesState.result} />
-		{:else}
-			<Error error={travelTimesState.error} />
-		{/if}
+		{:then result}
+			<Success {...result} />
+		{:catch error}
+			<Error error={error.message} />
+		{/await}
 	</Card>
 {/if}

--- a/src/lib/state/travelTimes.svelte.ts
+++ b/src/lib/state/travelTimes.svelte.ts
@@ -1,5 +1,10 @@
-import type { TravelTimesState } from '$lib/types';
+import type { TravelTimes, TravelTimesRequest } from '$lib/types';
 
-const travelTimesState: TravelTimesState = $state({ status: 'loading' });
+const travelTimesRequest: TravelTimesRequest = $state({ task: null });
 
-export default travelTimesState;
+export async function getTravelTimes(): Promise<TravelTimes> {
+	const res = await fetch('/api/travel-times');
+	return res.json() as Promise<TravelTimes>;
+}
+
+export default travelTimesRequest;

--- a/src/lib/state/travelTimes.svelte.ts
+++ b/src/lib/state/travelTimes.svelte.ts
@@ -3,7 +3,10 @@ import type { TravelTimes, TravelTimesRequest } from '$lib/types';
 const travelTimesRequest: TravelTimesRequest = $state({ task: null });
 
 export async function getTravelTimes(): Promise<TravelTimes> {
-	const res = await fetch('/api/travel-times');
+	const res = await fetch('/api/travel-times', { signal: AbortSignal.timeout(15_000) });
+	if (!res.ok) {
+		throw new Error(`Failed to fetch travel times: ${res.status} ${res.statusText}`);
+	}
 	return res.json() as Promise<TravelTimes>;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,20 +48,6 @@ export interface TravelTimes {
 	};
 }
 
-export type TravelTimesState =
-	| {
-			status: 'unset';
-	  }
-	| {
-			status: 'loading';
-	  }
-	| {
-			status: 'success';
-			result: TravelTimes;
-	  }
-	| {
-			status: 'error';
-			error: string;
-	  };
+export type TravelTimesRequest = { task: Promise<TravelTimes> | null };
 
 export type GoalStatus = 'met' | 'partial' | 'unmet';

--- a/src/routes/api/travel-times/+server.ts
+++ b/src/routes/api/travel-times/+server.ts
@@ -2,7 +2,13 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 
 import type { TravelTimes } from '$lib/types';
 
-export const GET: RequestHandler = () => {
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const GET: RequestHandler = async () => {
+	// Simulate a slow response
+	await sleep(300);
 	const result: TravelTimes = {
 		work: {
 			walk: {


### PR DESCRIPTION
The frontend is now fully hooked up for getting travel times!

This PR involves a few Svelte concepts:

* Realizing that the prior `TravelTimesState` type I had was recreating `Promise | null`!
* Use Svelte's `await` block https://svelte.dev/tutorial/svelte/await-blocks
* With how we store the Promise with universal reactivity (https://svelte.dev/tutorial/svelte/universal-reactivity), it's crucial that the promise is stored in an object rather than directly as `Promise | null` because we can only reassign properties on the object rather than the entire value.