### PR TITLE
Add generic code for biking

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,4 @@
-export interface WalkRoute {
-	timeMinutes: number;
-	distanceMiles: number;
-}
-
-export interface BikeRoute {
+export interface ActiveTransportRoute {
 	timeMinutes: number;
 	distanceMiles: number;
 }
@@ -15,8 +10,8 @@ export interface TransitRoute {
 
 export interface TravelTimes {
 	work: {
-		walk: WalkRoute;
-		bike: BikeRoute;
+		walk: ActiveTransportRoute;
+		bike: ActiveTransportRoute;
 	};
 	partner: {
 		transit: TransitRoute;
@@ -26,19 +21,19 @@ export interface TravelTimes {
 			name: string;
 			lines: string[];
 		};
-		walk: WalkRoute;
+		walk: ActiveTransportRoute;
 	};
 	park: {
 		closest: {
 			name: string;
 		};
-		walk: WalkRoute;
+		walk: ActiveTransportRoute;
 	};
 	farmersMarket: {
 		closest: {
 			name: string;
 		};
-		walk: WalkRoute;
+		walk: ActiveTransportRoute;
 	};
 	fractal: {
 		transit: TransitRoute;

--- a/src/routes/api/experiment/+server.ts
+++ b/src/routes/api/experiment/+server.ts
@@ -1,8 +1,13 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 
-import { computeWalk } from '$lib/server/gmaps';
+import { computeRoutes } from '$lib/server/gmaps';
 
 export const GET: RequestHandler = async () => {
-	const result = await computeWalk();
+	const result = await computeRoutes({
+		origin: '410 10th Ave, New York, NY',
+		dest: '1 Madison Ave, New York, NY 10010',
+		walk: true,
+		bike: true
+	});
 	return json(result);
 };


### PR DESCRIPTION
This adds a very nice API where you can specify for a certain route whether you want walking, biking, or transit, or any combination.

```typescript
computeRoutes({
		origin: '410 10th Ave, New York, NY',
		dest: '1 Madison Ave, New York, NY 10010',
		walk: true,
		bike: false
	});
```

Transit will be added in a follow up.

Kudos to Claude for figuring out the TypeScript modeling.