### PR TITLE
Add transit route Google Maps integration

### DIFF
--- a/src/routes/api/experiment/+server.ts
+++ b/src/routes/api/experiment/+server.ts
@@ -1,13 +1,11 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 
-import { computeRoutes } from '$lib/server/gmaps';
+import { computeTransitRoute } from '$lib/server/gmaps';
 
 export const GET: RequestHandler = async () => {
-	const result = await computeRoutes({
+	const result = await computeTransitRoute({
 		origin: '410 10th Ave, New York, NY',
-		dest: '1 Madison Ave, New York, NY 10010',
-		walk: true,
-		bike: true
+		dest: '1 Madison Ave, New York, NY 10010'
 	});
 	return json(result);
 };


### PR DESCRIPTION
The summary will be something like `7 -> 6`.

We only get the most optimal route rather than all routes. That's because this app is not meant to give a deep dive into how transit is between every place. It is only meant to give an initial preview of whether the location is acceptable or not. Then, the user should do further research, like Google Maps, for more detailed information.

This removes the generic code https://github.com/Eric-Arellano/nyc-apt-distances/pull/17 was doing. I realized that transit is different enough from biking and walking to not warrant trying to DRY. The declarative API will be built on top of this at a higher abstraction layer: the destination definitions.