### PR TITLE
Set consistent departure time for transit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@googlemaps/routing": "^2.0.1"
+				"@googlemaps/routing": "^2.0.1",
+				"luxon": "^3.6.1"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
@@ -20,6 +21,7 @@
 				"@tailwindcss/vite": "^4.0.0",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/svelte": "^5.2.4",
+				"@types/luxon": "^3.6.2",
 				"eslint": "^9.18.0",
 				"eslint-config-prettier": "^10.0.1",
 				"eslint-plugin-svelte": "^3.0.0",
@@ -1878,6 +1880,13 @@
 			"dependencies": {
 				"long": "*"
 			}
+		},
+		"node_modules/@types/luxon": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+			"integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "22.14.0",
@@ -4333,6 +4342,15 @@
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/luxon": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+			"integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@tailwindcss/vite": "^4.0.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/svelte": "^5.2.4",
+		"@types/luxon": "^3.6.2",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-plugin-svelte": "^3.0.0",
@@ -42,6 +43,7 @@
 		"vitest": "^3.0.0"
 	},
 	"dependencies": {
-		"@googlemaps/routing": "^2.0.1"
+		"@googlemaps/routing": "^2.0.1",
+		"luxon": "^3.6.1"
 	}
 }

--- a/src/lib/server/departureTime.test.ts
+++ b/src/lib/server/departureTime.test.ts
@@ -1,165 +1,87 @@
-import { describe, it, expect } from 'vitest';
-import { getNextDayTime, DayOfWeek } from './departureTime';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DateTime } from 'luxon';
+
+import { DayOfWeek, type TargetDate, getNextDayTime } from './departureTime';
 
 describe('getNextDayTime', () => {
-	interface DateParts {
-		year: number;
-		month: number;
-		date: number;
-		hours: number;
-		minutes: number;
-	}
+	beforeEach(() => {
+		vi.spyOn(DateTime, 'now').mockImplementation(
+			// April 11, 2023 was a Tuesday
+			() => DateTime.fromISO('2023-04-11T10:30:00', { zone: 'America/New_York' }) as DateTime<true>
+		);
+	});
 
-	interface TestCase {
-		description: string;
-		now: Date;
-		targetDay: DayOfWeek;
-		targetTime: { hours: number; minutes: number };
-		expected: DateParts;
-	}
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
 
-	const JAN = 0;
-	const FEB = 1;
-	const DEC = 11;
-	const STANDARD_TIME = { hours: 14, minutes: 30 };
-	const EARLY_TIME = { hours: 9, minutes: 0 };
-	const MIDNIGHT = { hours: 0, minutes: 0 };
+	it('throws an error when fromDate has an invalid timezone', () => {
+		const target: TargetDate = {
+			day: DayOfWeek.Wednesday,
+			hour: 15,
+			minute: 30
+		};
+		const invalidFromDate = DateTime.now().setZone('Europe/London') as DateTime<true>;
+		expect(() => getNextDayTime(target, invalidFromDate)).toThrow(
+			'Invalid timezone for input date'
+		);
+	});
 
-	const testCases: TestCase[] = [
-		{
-			description: 'should return today when target is same day and time has not passed',
-			now: new Date(2023, JAN, 9, 10, 0), // Monday
-			targetDay: DayOfWeek.Monday,
-			targetTime: STANDARD_TIME,
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 9,
-				...STANDARD_TIME
-			}
-		},
-		{
-			description: 'should return next week when target is same day but time has passed',
-			now: new Date(2023, JAN, 9, 15, 0), // Monday
-			targetDay: DayOfWeek.Monday,
-			targetTime: STANDARD_TIME,
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 16, // Next Monday
-				...STANDARD_TIME
-			}
-		},
-		{
-			description: 'should return now when current time is exactly target time',
-			now: new Date(2023, JAN, 9, STANDARD_TIME.hours, STANDARD_TIME.minutes), // Monday
-			targetDay: DayOfWeek.Monday,
-			targetTime: STANDARD_TIME,
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 9,
-				...STANDARD_TIME
-			}
-		},
-		{
-			description: 'should return later this week when target day is later in the week',
-			now: new Date(2023, JAN, 9, 10, 0), // Monday
-			targetDay: DayOfWeek.Wednesday,
-			targetTime: EARLY_TIME,
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 11, // Wednesday
-				...EARLY_TIME
-			}
-		},
-		{
-			description: 'should return next week when target day is earlier in the week',
-			now: new Date(2023, JAN, 11, 10, 0), // Wednesday
-			targetDay: DayOfWeek.Monday,
-			targetTime: EARLY_TIME,
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 16, // Next Monday
-				...EARLY_TIME
-			}
-		},
-		{
-			description: 'should handle time close to midnight correctly',
-			now: new Date(2023, JAN, 9, 23, 59), // Monday
-			targetDay: DayOfWeek.Tuesday,
-			targetTime: { hours: 0, minutes: 1 },
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 10, // Next day (Tuesday)
-				hours: 0,
-				minutes: 1
-			}
-		},
-		{
-			description: 'should handle time just after midnight correctly',
-			now: new Date(2023, JAN, 10, 0, 1), // Tuesday
-			targetDay: DayOfWeek.Tuesday,
-			targetTime: MIDNIGHT,
-			expected: {
-				year: 2023,
-				month: JAN,
-				date: 17, // Next Tuesday (time has passed)
-				...MIDNIGHT
-			}
-		},
-		{
-			description: 'should handle month boundaries correctly',
-			now: new Date(2023, JAN, 30, 12, 0), // Monday
-			targetDay: DayOfWeek.Wednesday,
-			targetTime: STANDARD_TIME,
-			expected: {
-				year: 2023,
-				month: FEB,
-				date: 1, // Wednesday
-				...STANDARD_TIME
-			}
-		},
-		{
-			description: 'should handle year boundaries correctly',
-			now: new Date(2023, DEC, 31, 12, 0), // Sunday
-			targetDay: DayOfWeek.Monday,
-			targetTime: { hours: 10, minutes: 0 },
-			expected: {
-				year: 2024,
-				month: JAN,
-				date: 1, // Monday
-				hours: 10,
-				minutes: 0
-			}
-		},
-		{
-			description: 'should handle leap year date calculations correctly',
-			now: new Date(2024, FEB, 28, 10, 0), // Feb 28, 2024 (leap year) is a Wednesday
-			targetDay: DayOfWeek.Thursday,
-			targetTime: STANDARD_TIME,
-			expected: {
-				year: 2024,
-				month: FEB,
-				date: 29, // Feb 29 (leap day)
-				...STANDARD_TIME
-			}
-		}
-	];
+	it('returns the correct date when target day is later in the same week', () => {
+		const target: TargetDate = {
+			day: DayOfWeek.Wednesday,
+			hour: 15,
+			minute: 30
+		};
+		const result = getNextDayTime(target);
+		expect(result.weekday).toBe(DayOfWeek.Wednesday);
+		expect(result.hour).toBe(15);
+		expect(result.minute).toBe(30);
+		expect(result.toISODate()).toBe('2023-04-12');
+	});
 
-	testCases.forEach(({ description, now, targetDay, targetTime, expected }) => {
-		it(description, () => {
-			const result = getNextDayTime({ day: targetDay, ...targetTime }, now);
-			expect(result.getFullYear()).toBe(expected.year);
-			expect(result.getMonth()).toBe(expected.month);
-			expect(result.getDate()).toBe(expected.date);
-			expect(result.getHours()).toBe(expected.hours);
-			expect(result.getMinutes()).toBe(expected.minutes);
-			expect(result.getSeconds()).toBe(0);
-			expect(result.getMilliseconds()).toBe(0);
-		});
+	it('returns the date for next week when target day is earlier in the week', () => {
+		// We're on Tuesday, so Monday already passed.
+		const target: TargetDate = {
+			day: DayOfWeek.Monday,
+			hour: 10,
+			minute: 0
+		};
+		const result = getNextDayTime(target);
+		expect(result.weekday).toBe(DayOfWeek.Monday);
+		expect(result.hour).toBe(10);
+		expect(result.minute).toBe(0);
+		expect(result.toISODate()).toBe('2023-04-17');
+	});
+
+	it('returns the date for next week when target day is the same as current day', () => {
+		const target: TargetDate = {
+			day: DayOfWeek.Tuesday,
+			hour: 9,
+			minute: 0
+		};
+		const result = getNextDayTime(target);
+		expect(result.weekday).toBe(DayOfWeek.Tuesday);
+		expect(result.hour).toBe(9);
+		expect(result.minute).toBe(0);
+		expect(result.toISODate()).toBe('2023-04-18');
+	});
+
+	it('handles DST boundaries correctly', () => {
+		// March 10, 2024 (just before DST begins in the US)
+		const beforeDST = DateTime.fromISO('2024-03-10T01:30:00', {
+			zone: 'America/New_York'
+		}) as DateTime<true>;
+		const target: TargetDate = {
+			day: DayOfWeek.Monday,
+			hour: 14,
+			minute: 30
+		};
+		const result = getNextDayTime(target, beforeDST);
+		expect(result.weekday).toBe(DayOfWeek.Monday);
+		expect(result.hour).toBe(14);
+		expect(result.minute).toBe(30);
+		expect(result.toISODate()).toBe('2024-03-11');
+		expect(result.zoneName).toBe('America/New_York');
 	});
 });

--- a/src/lib/server/departureTime.test.ts
+++ b/src/lib/server/departureTime.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DateTime } from 'luxon';
 
-import { DayOfWeek, type TargetDate, getNextDayTime } from './departureTime';
+import { DayOfWeek, type TargetDate, getNextDateTime } from './departureTime';
 
-describe('getNextDayTime', () => {
+describe('getNextDateTime', () => {
 	beforeEach(() => {
 		vi.spyOn(DateTime, 'now').mockImplementation(
 			// April 11, 2023 was a Tuesday
@@ -22,7 +22,7 @@ describe('getNextDayTime', () => {
 			minute: 30
 		};
 		const invalidFromDate = DateTime.now().setZone('Europe/London') as DateTime<true>;
-		expect(() => getNextDayTime(target, invalidFromDate)).toThrow(
+		expect(() => getNextDateTime(target, invalidFromDate)).toThrow(
 			'Invalid timezone for input date'
 		);
 	});
@@ -33,7 +33,7 @@ describe('getNextDayTime', () => {
 			hour: 15,
 			minute: 30
 		};
-		const result = getNextDayTime(target);
+		const result = getNextDateTime(target);
 		expect(result.weekday).toBe(DayOfWeek.Wednesday);
 		expect(result.hour).toBe(15);
 		expect(result.minute).toBe(30);
@@ -47,7 +47,7 @@ describe('getNextDayTime', () => {
 			hour: 10,
 			minute: 0
 		};
-		const result = getNextDayTime(target);
+		const result = getNextDateTime(target);
 		expect(result.weekday).toBe(DayOfWeek.Monday);
 		expect(result.hour).toBe(10);
 		expect(result.minute).toBe(0);
@@ -60,7 +60,7 @@ describe('getNextDayTime', () => {
 			hour: 9,
 			minute: 0
 		};
-		const result = getNextDayTime(target);
+		const result = getNextDateTime(target);
 		expect(result.weekday).toBe(DayOfWeek.Tuesday);
 		expect(result.hour).toBe(9);
 		expect(result.minute).toBe(0);
@@ -77,7 +77,7 @@ describe('getNextDayTime', () => {
 			hour: 14,
 			minute: 30
 		};
-		const result = getNextDayTime(target, beforeDST);
+		const result = getNextDateTime(target, beforeDST);
 		expect(result.weekday).toBe(DayOfWeek.Monday);
 		expect(result.hour).toBe(14);
 		expect(result.minute).toBe(30);

--- a/src/lib/server/departureTime.test.ts
+++ b/src/lib/server/departureTime.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { getNextDayTime, DayOfWeek } from './departureTime.js';
+
+describe('getNextDayTime', () => {
+	it('should return today when target is same day and time has not passed', () => {
+		const now = new Date(2023, 0, 9, 10, 0); // Monday, Jan 9, 2023, 10:00
+		const targetDay = DayOfWeek.Monday;
+		const targetHours = 14;
+		const targetMinutes = 30;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(now.getFullYear());
+		expect(result.getMonth()).toBe(now.getMonth());
+		expect(result.getDate()).toBe(now.getDate());
+		expect(result.getHours()).toBe(targetHours);
+		expect(result.getMinutes()).toBe(targetMinutes);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should return next week when target is same day but time has passed', () => {
+		const now = new Date(2023, 0, 9, 15, 0); // Monday, Jan 9, 2023, 15:00
+		const targetDay = DayOfWeek.Monday;
+		const targetHours = 14;
+		const targetMinutes = 30;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(0);
+		expect(result.getDate()).toBe(16); // Next Monday
+		expect(result.getHours()).toBe(14);
+		expect(result.getMinutes()).toBe(30);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should return later this week when target day is later in the week', () => {
+		const now = new Date(2023, 0, 9, 10, 0); // Monday, Jan 9, 2023, 10:00
+		const targetDay = DayOfWeek.Wednesday;
+		const targetHours = 9;
+		const targetMinutes = 0;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(0);
+		expect(result.getDate()).toBe(11); // Wednesday
+		expect(result.getHours()).toBe(9);
+		expect(result.getMinutes()).toBe(0);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should return next week when target day is earlier in the week', () => {
+		const now = new Date(2023, 0, 11, 10, 0); // Wednesday, Jan 11, 2023, 10:00
+		const targetDay = DayOfWeek.Monday;
+		const targetHours = 9;
+		const targetMinutes = 0;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(0);
+		expect(result.getDate()).toBe(16); // Next Monday
+		expect(result.getHours()).toBe(9);
+		expect(result.getMinutes()).toBe(0);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should return now when current time is exactly target time', () => {
+		const now = new Date(2023, 0, 9, 14, 30); // Monday, Jan 9, 2023, 14:30
+		const targetDay = DayOfWeek.Monday;
+		const targetHours = 14;
+		const targetMinutes = 30;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(0);
+		expect(result.getDate()).toBe(9); // This Monday
+		expect(result.getHours()).toBe(14);
+		expect(result.getMinutes()).toBe(30);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should handle time close to midnight correctly', () => {
+		const now = new Date(2023, 0, 9, 23, 59); // Monday, Jan 9, 2023, 23:59
+		const targetDay = DayOfWeek.Tuesday;
+		const targetHours = 0;
+		const targetMinutes = 1;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(0);
+		expect(result.getDate()).toBe(10); // Next day (Tuesday)
+		expect(result.getHours()).toBe(0);
+		expect(result.getMinutes()).toBe(1);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should handle time just after midnight correctly', () => {
+		const now = new Date(2023, 0, 10, 0, 1); // Tuesday, Jan 10, 2023, 00:01
+		const targetDay = DayOfWeek.Tuesday;
+		const targetHours = 0;
+		const targetMinutes = 0;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(0);
+		expect(result.getDate()).toBe(17); // Next Tuesday (time has passed)
+		expect(result.getHours()).toBe(0);
+		expect(result.getMinutes()).toBe(0);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should handle month boundaries correctly', () => {
+		const now = new Date(2023, 0, 30, 12, 0); // Monday, Jan 30, 2023, 12:00
+		const targetDay = DayOfWeek.Wednesday;
+		const targetHours = 14;
+		const targetMinutes = 30;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2023);
+		expect(result.getMonth()).toBe(1); // February
+		expect(result.getDate()).toBe(1); // Wednesday, Feb 1
+		expect(result.getHours()).toBe(14);
+		expect(result.getMinutes()).toBe(30);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	it('should handle year boundaries correctly', () => {
+		const now = new Date(2023, 11, 31, 12, 0); // Sunday, Dec 31, 2023, 12:00
+		const targetDay = DayOfWeek.Monday;
+		const targetHours = 10;
+		const targetMinutes = 0;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2024);
+		expect(result.getMonth()).toBe(0); // January
+		expect(result.getDate()).toBe(1); // Monday, Jan 1, 2024
+		expect(result.getHours()).toBe(10);
+		expect(result.getMinutes()).toBe(0);
+		expect(result.getSeconds()).toBe(0);
+		expect(result.getMilliseconds()).toBe(0);
+	});
+
+	// 11. Test with all days of the week
+	it('should work correctly for all days of the week', () => {
+		const now = new Date(2023, 0, 9, 12, 0); // Monday, Jan 9, 2023, 12:00
+		const targetHours = 15;
+		const targetMinutes = 30;
+
+		// Expected dates for each day of the week
+		const expectedDates = [
+			15, // Sunday (Jan 15)
+			9, // Monday (Jan 9 - today, time not passed yet)
+			10, // Tuesday (Jan 10)
+			11, // Wednesday (Jan 11)
+			12, // Thursday (Jan 12)
+			13, // Friday (Jan 13)
+			14 // Saturday (Jan 14)
+		];
+
+		// Test each day of the week
+		for (let day = 0; day < 7; day++) {
+			// Act
+			const result = getNextDayTime(day, targetHours, targetMinutes, now);
+
+			// Assert
+			expect(result.getFullYear()).toBe(2023);
+			expect(result.getMonth()).toBe(0);
+			expect(result.getDate()).toBe(expectedDates[day]);
+			expect(result.getHours()).toBe(targetHours);
+			expect(result.getMinutes()).toBe(targetMinutes);
+			expect(result.getSeconds()).toBe(0);
+			expect(result.getMilliseconds()).toBe(0);
+		}
+	});
+
+	it('should handle leap year date calculations correctly', () => {
+		// Feb 28, 2024 (leap year) is a Wednesday
+		const now = new Date(2024, 1, 28, 10, 0);
+		const targetDay = DayOfWeek.Thursday;
+		const targetHours = 14;
+		const targetMinutes = 30;
+
+		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+
+		expect(result.getFullYear()).toBe(2024);
+		expect(result.getMonth()).toBe(1); // February
+		expect(result.getDate()).toBe(29); // Feb 29 (leap day)
+		expect(result.getHours()).toBe(14);
+		expect(result.getMinutes()).toBe(30);
+	});
+});

--- a/src/lib/server/departureTime.test.ts
+++ b/src/lib/server/departureTime.test.ts
@@ -1,206 +1,165 @@
 import { describe, it, expect } from 'vitest';
-import { getNextDayTime, DayOfWeek } from './departureTime.js';
+import { getNextDayTime, DayOfWeek } from './departureTime';
 
 describe('getNextDayTime', () => {
-	it('should return today when target is same day and time has not passed', () => {
-		const now = new Date(2023, 0, 9, 10, 0); // Monday, Jan 9, 2023, 10:00
-		const targetDay = DayOfWeek.Monday;
-		const targetHours = 14;
-		const targetMinutes = 30;
+	interface DateParts {
+		year: number;
+		month: number;
+		date: number;
+		hours: number;
+		minutes: number;
+	}
 
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
+	interface TestCase {
+		description: string;
+		now: Date;
+		targetDay: DayOfWeek;
+		targetTime: { hours: number; minutes: number };
+		expected: DateParts;
+	}
 
-		expect(result.getFullYear()).toBe(now.getFullYear());
-		expect(result.getMonth()).toBe(now.getMonth());
-		expect(result.getDate()).toBe(now.getDate());
-		expect(result.getHours()).toBe(targetHours);
-		expect(result.getMinutes()).toBe(targetMinutes);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
+	const JAN = 0;
+	const FEB = 1;
+	const DEC = 11;
+	const STANDARD_TIME = { hours: 14, minutes: 30 };
+	const EARLY_TIME = { hours: 9, minutes: 0 };
+	const MIDNIGHT = { hours: 0, minutes: 0 };
 
-	it('should return next week when target is same day but time has passed', () => {
-		const now = new Date(2023, 0, 9, 15, 0); // Monday, Jan 9, 2023, 15:00
-		const targetDay = DayOfWeek.Monday;
-		const targetHours = 14;
-		const targetMinutes = 30;
+	const testCases: TestCase[] = [
+		{
+			description: 'should return today when target is same day and time has not passed',
+			now: new Date(2023, JAN, 9, 10, 0), // Monday
+			targetDay: DayOfWeek.Monday,
+			targetTime: STANDARD_TIME,
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 9,
+				...STANDARD_TIME
+			}
+		},
+		{
+			description: 'should return next week when target is same day but time has passed',
+			now: new Date(2023, JAN, 9, 15, 0), // Monday
+			targetDay: DayOfWeek.Monday,
+			targetTime: STANDARD_TIME,
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 16, // Next Monday
+				...STANDARD_TIME
+			}
+		},
+		{
+			description: 'should return now when current time is exactly target time',
+			now: new Date(2023, JAN, 9, STANDARD_TIME.hours, STANDARD_TIME.minutes), // Monday
+			targetDay: DayOfWeek.Monday,
+			targetTime: STANDARD_TIME,
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 9,
+				...STANDARD_TIME
+			}
+		},
+		{
+			description: 'should return later this week when target day is later in the week',
+			now: new Date(2023, JAN, 9, 10, 0), // Monday
+			targetDay: DayOfWeek.Wednesday,
+			targetTime: EARLY_TIME,
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 11, // Wednesday
+				...EARLY_TIME
+			}
+		},
+		{
+			description: 'should return next week when target day is earlier in the week',
+			now: new Date(2023, JAN, 11, 10, 0), // Wednesday
+			targetDay: DayOfWeek.Monday,
+			targetTime: EARLY_TIME,
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 16, // Next Monday
+				...EARLY_TIME
+			}
+		},
+		{
+			description: 'should handle time close to midnight correctly',
+			now: new Date(2023, JAN, 9, 23, 59), // Monday
+			targetDay: DayOfWeek.Tuesday,
+			targetTime: { hours: 0, minutes: 1 },
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 10, // Next day (Tuesday)
+				hours: 0,
+				minutes: 1
+			}
+		},
+		{
+			description: 'should handle time just after midnight correctly',
+			now: new Date(2023, JAN, 10, 0, 1), // Tuesday
+			targetDay: DayOfWeek.Tuesday,
+			targetTime: MIDNIGHT,
+			expected: {
+				year: 2023,
+				month: JAN,
+				date: 17, // Next Tuesday (time has passed)
+				...MIDNIGHT
+			}
+		},
+		{
+			description: 'should handle month boundaries correctly',
+			now: new Date(2023, JAN, 30, 12, 0), // Monday
+			targetDay: DayOfWeek.Wednesday,
+			targetTime: STANDARD_TIME,
+			expected: {
+				year: 2023,
+				month: FEB,
+				date: 1, // Wednesday
+				...STANDARD_TIME
+			}
+		},
+		{
+			description: 'should handle year boundaries correctly',
+			now: new Date(2023, DEC, 31, 12, 0), // Sunday
+			targetDay: DayOfWeek.Monday,
+			targetTime: { hours: 10, minutes: 0 },
+			expected: {
+				year: 2024,
+				month: JAN,
+				date: 1, // Monday
+				hours: 10,
+				minutes: 0
+			}
+		},
+		{
+			description: 'should handle leap year date calculations correctly',
+			now: new Date(2024, FEB, 28, 10, 0), // Feb 28, 2024 (leap year) is a Wednesday
+			targetDay: DayOfWeek.Thursday,
+			targetTime: STANDARD_TIME,
+			expected: {
+				year: 2024,
+				month: FEB,
+				date: 29, // Feb 29 (leap day)
+				...STANDARD_TIME
+			}
+		}
+	];
 
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(0);
-		expect(result.getDate()).toBe(16); // Next Monday
-		expect(result.getHours()).toBe(14);
-		expect(result.getMinutes()).toBe(30);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should return later this week when target day is later in the week', () => {
-		const now = new Date(2023, 0, 9, 10, 0); // Monday, Jan 9, 2023, 10:00
-		const targetDay = DayOfWeek.Wednesday;
-		const targetHours = 9;
-		const targetMinutes = 0;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(0);
-		expect(result.getDate()).toBe(11); // Wednesday
-		expect(result.getHours()).toBe(9);
-		expect(result.getMinutes()).toBe(0);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should return next week when target day is earlier in the week', () => {
-		const now = new Date(2023, 0, 11, 10, 0); // Wednesday, Jan 11, 2023, 10:00
-		const targetDay = DayOfWeek.Monday;
-		const targetHours = 9;
-		const targetMinutes = 0;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(0);
-		expect(result.getDate()).toBe(16); // Next Monday
-		expect(result.getHours()).toBe(9);
-		expect(result.getMinutes()).toBe(0);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should return now when current time is exactly target time', () => {
-		const now = new Date(2023, 0, 9, 14, 30); // Monday, Jan 9, 2023, 14:30
-		const targetDay = DayOfWeek.Monday;
-		const targetHours = 14;
-		const targetMinutes = 30;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(0);
-		expect(result.getDate()).toBe(9); // This Monday
-		expect(result.getHours()).toBe(14);
-		expect(result.getMinutes()).toBe(30);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should handle time close to midnight correctly', () => {
-		const now = new Date(2023, 0, 9, 23, 59); // Monday, Jan 9, 2023, 23:59
-		const targetDay = DayOfWeek.Tuesday;
-		const targetHours = 0;
-		const targetMinutes = 1;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(0);
-		expect(result.getDate()).toBe(10); // Next day (Tuesday)
-		expect(result.getHours()).toBe(0);
-		expect(result.getMinutes()).toBe(1);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should handle time just after midnight correctly', () => {
-		const now = new Date(2023, 0, 10, 0, 1); // Tuesday, Jan 10, 2023, 00:01
-		const targetDay = DayOfWeek.Tuesday;
-		const targetHours = 0;
-		const targetMinutes = 0;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(0);
-		expect(result.getDate()).toBe(17); // Next Tuesday (time has passed)
-		expect(result.getHours()).toBe(0);
-		expect(result.getMinutes()).toBe(0);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should handle month boundaries correctly', () => {
-		const now = new Date(2023, 0, 30, 12, 0); // Monday, Jan 30, 2023, 12:00
-		const targetDay = DayOfWeek.Wednesday;
-		const targetHours = 14;
-		const targetMinutes = 30;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2023);
-		expect(result.getMonth()).toBe(1); // February
-		expect(result.getDate()).toBe(1); // Wednesday, Feb 1
-		expect(result.getHours()).toBe(14);
-		expect(result.getMinutes()).toBe(30);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	it('should handle year boundaries correctly', () => {
-		const now = new Date(2023, 11, 31, 12, 0); // Sunday, Dec 31, 2023, 12:00
-		const targetDay = DayOfWeek.Monday;
-		const targetHours = 10;
-		const targetMinutes = 0;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2024);
-		expect(result.getMonth()).toBe(0); // January
-		expect(result.getDate()).toBe(1); // Monday, Jan 1, 2024
-		expect(result.getHours()).toBe(10);
-		expect(result.getMinutes()).toBe(0);
-		expect(result.getSeconds()).toBe(0);
-		expect(result.getMilliseconds()).toBe(0);
-	});
-
-	// 11. Test with all days of the week
-	it('should work correctly for all days of the week', () => {
-		const now = new Date(2023, 0, 9, 12, 0); // Monday, Jan 9, 2023, 12:00
-		const targetHours = 15;
-		const targetMinutes = 30;
-
-		// Expected dates for each day of the week
-		const expectedDates = [
-			15, // Sunday (Jan 15)
-			9, // Monday (Jan 9 - today, time not passed yet)
-			10, // Tuesday (Jan 10)
-			11, // Wednesday (Jan 11)
-			12, // Thursday (Jan 12)
-			13, // Friday (Jan 13)
-			14 // Saturday (Jan 14)
-		];
-
-		// Test each day of the week
-		for (let day = 0; day < 7; day++) {
-			// Act
-			const result = getNextDayTime(day, targetHours, targetMinutes, now);
-
-			// Assert
-			expect(result.getFullYear()).toBe(2023);
-			expect(result.getMonth()).toBe(0);
-			expect(result.getDate()).toBe(expectedDates[day]);
-			expect(result.getHours()).toBe(targetHours);
-			expect(result.getMinutes()).toBe(targetMinutes);
+	testCases.forEach(({ description, now, targetDay, targetTime, expected }) => {
+		it(description, () => {
+			const result = getNextDayTime(targetDay, targetTime.hours, targetTime.minutes, now);
+			expect(result.getFullYear()).toBe(expected.year);
+			expect(result.getMonth()).toBe(expected.month);
+			expect(result.getDate()).toBe(expected.date);
+			expect(result.getHours()).toBe(expected.hours);
+			expect(result.getMinutes()).toBe(expected.minutes);
 			expect(result.getSeconds()).toBe(0);
 			expect(result.getMilliseconds()).toBe(0);
-		}
-	});
-
-	it('should handle leap year date calculations correctly', () => {
-		// Feb 28, 2024 (leap year) is a Wednesday
-		const now = new Date(2024, 1, 28, 10, 0);
-		const targetDay = DayOfWeek.Thursday;
-		const targetHours = 14;
-		const targetMinutes = 30;
-
-		const result = getNextDayTime(targetDay, targetHours, targetMinutes, now);
-
-		expect(result.getFullYear()).toBe(2024);
-		expect(result.getMonth()).toBe(1); // February
-		expect(result.getDate()).toBe(29); // Feb 29 (leap day)
-		expect(result.getHours()).toBe(14);
-		expect(result.getMinutes()).toBe(30);
+		});
 	});
 });

--- a/src/lib/server/departureTime.test.ts
+++ b/src/lib/server/departureTime.test.ts
@@ -152,7 +152,7 @@ describe('getNextDayTime', () => {
 
 	testCases.forEach(({ description, now, targetDay, targetTime, expected }) => {
 		it(description, () => {
-			const result = getNextDayTime(targetDay, targetTime.hours, targetTime.minutes, now);
+			const result = getNextDayTime({ day: targetDay, ...targetTime }, now);
 			expect(result.getFullYear()).toBe(expected.year);
 			expect(result.getMonth()).toBe(expected.month);
 			expect(result.getDate()).toBe(expected.date);

--- a/src/lib/server/departureTime.ts
+++ b/src/lib/server/departureTime.ts
@@ -8,23 +8,25 @@ export enum DayOfWeek {
 	Saturday = 6
 }
 
-export function getNextDayTime(
-	targetDay: DayOfWeek,
-	targetHours: number,
-	targetMinutes: number,
-	fromDate: Date = new Date()
-): Date {
+// Time should be specified in ET.
+export interface TargetDate {
+	day: DayOfWeek;
+	hours: number;
+	minutes: number;
+}
+
+export function getNextDayTime(target: TargetDate, fromDate: Date = new Date()): Date {
 	const daysToAdd = computeDaysToAdd({
 		currentDay: fromDate.getDay(),
 		currentHours: fromDate.getHours(),
 		currentMinutes: fromDate.getMinutes(),
-		targetDay,
-		targetHours,
-		targetMinutes
+		targetDay: target.day,
+		targetHours: target.hours,
+		targetMinutes: target.minutes
 	});
 	const result = new Date(fromDate);
 	result.setDate(fromDate.getDate() + daysToAdd);
-	result.setHours(targetHours, targetMinutes, 0, 0);
+	result.setHours(target.hours, target.minutes, 0, 0);
 	return result;
 }
 

--- a/src/lib/server/departureTime.ts
+++ b/src/lib/server/departureTime.ts
@@ -1,0 +1,57 @@
+export enum DayOfWeek {
+	Sunday = 0,
+	Monday = 1,
+	Tuesday = 2,
+	Wednesday = 3,
+	Thursday = 4,
+	Friday = 5,
+	Saturday = 6
+}
+
+export function getNextDayTime(
+	targetDay: DayOfWeek,
+	targetHours: number,
+	targetMinutes: number,
+	fromDate: Date = new Date()
+): Date {
+	const daysToAdd = computeDaysToAdd({
+		currentDay: fromDate.getDay(),
+		currentHours: fromDate.getHours(),
+		currentMinutes: fromDate.getMinutes(),
+		targetDay,
+		targetHours,
+		targetMinutes
+	});
+	const result = new Date(fromDate);
+	result.setDate(fromDate.getDate() + daysToAdd);
+	result.setHours(targetHours, targetMinutes, 0, 0);
+	return result;
+}
+
+function computeDaysToAdd(options: {
+	currentDay: number;
+	currentHours: number;
+	currentMinutes: number;
+	targetDay: number;
+	targetHours: number;
+	targetMinutes: number;
+}): number {
+	const { currentDay, currentHours, currentMinutes, targetDay, targetHours, targetMinutes } =
+		options;
+
+	if (currentDay === targetDay) {
+		const timeHasPassed =
+			currentHours > targetHours ||
+			(currentHours === targetHours && currentMinutes > targetMinutes);
+		return timeHasPassed ? 7 : 0;
+	}
+
+	// Target day is later in this week.
+	if (currentDay < targetDay) {
+		return targetDay - currentDay;
+	}
+
+	// Else, target day was earlier in this week. So,
+	// use the following week.
+	return 7 - (currentDay - targetDay);
+}

--- a/src/lib/server/departureTime.ts
+++ b/src/lib/server/departureTime.ts
@@ -18,7 +18,7 @@ export interface TargetDate {
 	minute: number;
 }
 
-export function getNextDayTime(
+export function getNextDateTime(
 	target: TargetDate,
 	fromDate: DateTime<true> = DateTime.now().setZone('America/New_York') as DateTime<true>
 ): DateTime<true> {

--- a/src/lib/server/gmaps.ts
+++ b/src/lib/server/gmaps.ts
@@ -1,8 +1,7 @@
 import { RoutesClient } from '@googlemaps/routing';
 
 import type { ActiveTransportRoute, TransitRoute } from '$lib/types';
-import { getNextDayTime, type TargetDate } from './departureTime';
-import { DateTime } from 'luxon';
+import { getNextDateTime, type TargetDate } from './departureTime';
 
 const ROUTES_CLIENT = new RoutesClient({ apiKey: process.env['GOOGLE_MAPS_TOKEN'] });
 
@@ -52,7 +51,7 @@ export async function computeTransitRoute(options: {
 	targetDeparture: TargetDate;
 }): Promise<TransitRoute> {
 	const { origin, dest, targetDeparture } = options;
-	const actualDeparture = getNextDayTime(targetDeparture);
+	const actualDeparture = getNextDateTime(targetDeparture);
 	const response = await ROUTES_CLIENT.computeRoutes(
 		{
 			origin: { address: origin },

--- a/src/lib/server/gmaps.ts
+++ b/src/lib/server/gmaps.ts
@@ -1,6 +1,7 @@
 import { RoutesClient } from '@googlemaps/routing';
 
 import type { ActiveTransportRoute, TransitRoute } from '$lib/types';
+import { getNextDayTime, type TargetDate } from './departureTime';
 
 const ROUTES_CLIENT = new RoutesClient({ apiKey: process.env['GOOGLE_MAPS_TOKEN'] });
 
@@ -47,13 +48,16 @@ export async function computeActiveTransportRoute(options: {
 export async function computeTransitRoute(options: {
 	origin: string;
 	dest: string;
+	targetDeparture: TargetDate;
 }): Promise<TransitRoute> {
-	const { origin, dest } = options;
+	const { origin, dest, targetDeparture } = options;
+	const actualDeparture = getNextDayTime(targetDeparture);
 	const response = await ROUTES_CLIENT.computeRoutes(
 		{
 			origin: { address: origin },
 			destination: { address: dest },
-			travelMode: 'TRANSIT'
+			travelMode: 'TRANSIT',
+			departureTime: { seconds: actualDeparture.getTime() / 1000 }
 		},
 		{
 			otherArgs: {

--- a/src/lib/server/gmaps.ts
+++ b/src/lib/server/gmaps.ts
@@ -76,12 +76,15 @@ export async function computeTransitRoute(options: {
 	}
 	const leg = route.legs[0];
 
-	const steps = leg.steps
-		?.map((step) => step.transitDetails?.transitLine?.nameShort)
+	const summary = leg
+		.steps!.map((step) => {
+			const name = step.transitDetails?.transitLine?.nameShort;
+			return name?.replace(' Line', '').replace(' Train', '');
+		})
 		.filter((name) => name !== null && name !== undefined)
-		.map((name) => name.replace(' Line', '').replace(' Train', ''));
+		.join(' -> ');
 	return {
 		timeMinutes: secondsStringToMinutes(route.duration!.seconds as string),
-		summary: steps?.join(' -> ') ?? 'unknown'
+		summary
 	};
 }

--- a/src/lib/server/gmaps.ts
+++ b/src/lib/server/gmaps.ts
@@ -2,6 +2,7 @@ import { RoutesClient } from '@googlemaps/routing';
 
 import type { ActiveTransportRoute, TransitRoute } from '$lib/types';
 import { getNextDayTime, type TargetDate } from './departureTime';
+import { DateTime } from 'luxon';
 
 const ROUTES_CLIENT = new RoutesClient({ apiKey: process.env['GOOGLE_MAPS_TOKEN'] });
 
@@ -57,7 +58,7 @@ export async function computeTransitRoute(options: {
 			origin: { address: origin },
 			destination: { address: dest },
 			travelMode: 'TRANSIT',
-			departureTime: { seconds: actualDeparture.getTime() / 1000 }
+			departureTime: { seconds: actualDeparture.toMillis() / 1000 }
 		},
 		{
 			otherArgs: {

--- a/src/routes/api/experiment/+server.ts
+++ b/src/routes/api/experiment/+server.ts
@@ -7,7 +7,7 @@ export const GET: RequestHandler = async () => {
 	const result = await computeTransitRoute({
 		origin: '410 10th Ave, New York, NY',
 		dest: '1 Madison Ave, New York, NY 10010',
-		targetDeparture: { day: DayOfWeek.Monday, hours: 9, minutes: 0 }
+		targetDeparture: { day: DayOfWeek.Monday, hour: 9, minute: 0 }
 	});
 	return json(result);
 };

--- a/src/routes/api/experiment/+server.ts
+++ b/src/routes/api/experiment/+server.ts
@@ -1,11 +1,13 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 import { computeTransitRoute } from '$lib/server/gmaps';
+import { DayOfWeek } from '$lib/server/departureTime';
 
 export const GET: RequestHandler = async () => {
 	const result = await computeTransitRoute({
 		origin: '410 10th Ave, New York, NY',
-		dest: '1 Madison Ave, New York, NY 10010'
+		dest: '1 Madison Ave, New York, NY 10010',
+		targetDeparture: { day: DayOfWeek.Monday, hours: 9, minutes: 0 }
 	});
 	return json(result);
 };


### PR DESCRIPTION
Now,c allers set the day of the week and time, like Monday at 9 am. 

Google Maps Route API lets us specify up to 100 days in the future, so we always use a future date within the current or following week.

Using Luxon is important so that we can consistently use ET as the time zone, rather than using UTC or local time. This is feasible because the app is hardcoded to NYC. It's important to not use local time because I don't know where the server will be deployed.