### PR TITLE
Add authentication via JWT to backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@googlemaps/google-maps-services-js": "^3.4.1",
 				"@googlemaps/routing": "^2.0.1",
+				"jsonwebtoken": "^9.0.2",
 				"luxon": "^3.6.1"
 			},
 			"devDependencies": {
@@ -22,6 +23,7 @@
 				"@tailwindcss/vite": "^4.0.0",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/svelte": "^5.2.4",
+				"@types/jsonwebtoken": "^9.0.9",
 				"@types/luxon": "^3.6.2",
 				"eslint": "^9.18.0",
 				"eslint-config-prettier": "^10.0.1",
@@ -1442,9 +1444,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.20.4",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.4.tgz",
-			"integrity": "sha512-B3Y1mb1Qjt57zXLVch5tfqsK/ebHe6uYTcFSnGFNwRpId3+fplLgQK6Z2zhDVBezSsPuhDq6Pry+9PA88ocN6Q==",
+			"version": "2.20.7",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.7.tgz",
+			"integrity": "sha512-dVbLMubpJJSLI4OYB+yWYNHGAhgc2bVevWuBjDj8jFUXIJOAnLwYP3vsmtcgoxNGUXoq0rHS5f7MFCsryb6nzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1894,6 +1896,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/jsonwebtoken": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
+			"integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/long": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-5.0.0.tgz",
@@ -1908,6 +1921,13 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
 			"integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3356,9 +3376,9 @@
 			}
 		},
 		"node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+			"version": "6.4.4",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+			"integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -4067,6 +4087,49 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/jwa": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -4414,11 +4477,53 @@
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
 			"license": "MIT"
 		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"license": "MIT"
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"license": "MIT"
 		},
 		"node_modules/long": {
@@ -4800,8 +4905,6 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5421,7 +5524,6 @@
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
 			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5790,6 +5892,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+			"integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
 		"node_modules/tinypool": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -5975,15 +6094,18 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-			"integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
+			"integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
+				"fdir": "^6.4.3",
+				"picomatch": "^4.0.2",
 				"postcss": "^8.5.3",
-				"rollup": "^4.30.1"
+				"rollup": "^4.34.9",
+				"tinyglobby": "^0.2.12"
 			},
 			"bin": {
 				"vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@tailwindcss/vite": "^4.0.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/svelte": "^5.2.4",
+		"@types/jsonwebtoken": "^9.0.9",
 		"@types/luxon": "^3.6.2",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",
@@ -45,6 +46,7 @@
 	"dependencies": {
 		"@googlemaps/google-maps-services-js": "^3.4.1",
 		"@googlemaps/routing": "^2.0.1",
+		"jsonwebtoken": "^9.0.2",
 		"luxon": "^3.6.1"
 	}
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,19 @@
+import { isValidSession } from '$lib/server/auth';
+import { json, type Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	if (!event.url.pathname.startsWith('/api/') || event.url.pathname.startsWith('/api/login')) {
+		return resolve(event);
+	}
+
+	const token = event.request.headers.get('Authorization')?.split('Bearer ')[1];
+	if (!token || !isValidSession(token)) {
+		return json(
+			{ error: 'Unauthorized' },
+			{
+				status: 401
+			}
+		);
+	}
+	return resolve(event);
+};

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,10 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET, SITE_PASSWORD } from './env';
 
-export function createSession(): string {
-	return jwt.sign({}, JWT_SECRET, { expiresIn: '30d' });
-}
-
 export function isValidSession(token: string): boolean {
 	try {
 		jwt.verify(token, JWT_SECRET);
@@ -18,5 +14,6 @@ type AuthResult = { success: true; token: string } | { success: false };
 
 export function login(password: string): AuthResult {
 	if (password !== SITE_PASSWORD) return { success: false };
-	return { success: true, token: createSession() };
+	const token = jwt.sign({}, JWT_SECRET, { expiresIn: '30d' });
+	return { success: true, token };
 }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,0 +1,22 @@
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET, SITE_PASSWORD } from './env';
+
+export function createSession(): string {
+	return jwt.sign({}, JWT_SECRET, { expiresIn: '30d' });
+}
+
+export function isValidSession(token: string): boolean {
+	try {
+		jwt.verify(token, JWT_SECRET);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+type AuthResult = { success: true; token: string } | { success: false };
+
+export function login(password: string): AuthResult {
+	if (password !== SITE_PASSWORD) return { success: false };
+	return { success: true, token: createSession() };
+}

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -5,6 +5,7 @@ export function isValidSession(token: string): boolean {
 	try {
 		jwt.verify(token, JWT_SECRET);
 		return true;
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	} catch (e) {
 		return false;
 	}

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,12 +1,10 @@
-let gmapsToken: string | undefined;
-
-export function googleMapsToken(): string {
-	if (gmapsToken) return gmapsToken;
-	gmapsToken = process.env['GOOGLE_MAPS_TOKEN'];
-	if (!gmapsToken) {
-		throw new Error('GOOGLE_MAPS_TOKEN must be set as an env var.');
+function requireEnvVar(key: string): string {
+	const val = process.env[key];
+	if (!val) {
+		throw new Error(`${key} must be set as an env var.`);
 	}
-	return gmapsToken;
+	return val;
 }
 
+export const GMAPS_TOKEN = requireEnvVar('GOOGLE_MAPS_TOKEN');
 export const USE_MOCK_DATA = !!process.env['MOCK'];

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -8,3 +8,5 @@ function requireEnvVar(key: string): string {
 
 export const GMAPS_TOKEN = requireEnvVar('GOOGLE_MAPS_TOKEN');
 export const USE_MOCK_DATA = !!process.env['MOCK'];
+export const SITE_PASSWORD = requireEnvVar('SITE_PASSWORD');
+export const JWT_SECRET = requireEnvVar('JWT_SECRET');

--- a/src/lib/server/gmapsGeocoding.ts
+++ b/src/lib/server/gmapsGeocoding.ts
@@ -1,12 +1,12 @@
 import { Client } from '@googlemaps/google-maps-services-js';
 
-import { googleMapsToken } from './env';
+import { GMAPS_TOKEN } from './env';
 
 const GEOCODING_CLIENT = new Client();
 
 export async function geocode(address: string): Promise<{ latitude: number; longitude: number }> {
 	const resp = await GEOCODING_CLIENT.geocode({
-		params: { key: googleMapsToken(), address: address }
+		params: { key: GMAPS_TOKEN, address: address }
 	});
 	const results = resp.data.results;
 	if (results.length !== 1) {

--- a/src/lib/server/gmapsRouting.ts
+++ b/src/lib/server/gmapsRouting.ts
@@ -2,9 +2,9 @@ import { RoutesClient } from '@googlemaps/routing';
 
 import type { ActiveTransportRoute, TransitRoute } from '$lib/types';
 import { getNextDateTime, type TargetDate } from './departureTime';
-import { googleMapsToken } from './env';
+import { GMAPS_TOKEN } from './env';
 
-const ROUTES_CLIENT = new RoutesClient({ apiKey: googleMapsToken() });
+const ROUTES_CLIENT = new RoutesClient({ apiKey: GMAPS_TOKEN });
 
 function secondsStringToMinutes(seconds: string): number {
 	return Math.round(Number(seconds) / 60);

--- a/src/routes/api/experiment/+server.ts
+++ b/src/routes/api/experiment/+server.ts
@@ -1,8 +1,0 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
-
-import { geocode } from '$lib/server/gmapsGeocoding';
-
-export const GET: RequestHandler = async () => {
-	const result = await geocode('410 10th Ave, New York, NY');
-	return json(result);
-};

--- a/src/routes/api/login/+server.ts
+++ b/src/routes/api/login/+server.ts
@@ -1,0 +1,22 @@
+import { type RequestHandler, json } from '@sveltejs/kit';
+
+import { login } from '$lib/server/auth';
+
+export const POST: RequestHandler = async ({ request }) => {
+	let data;
+	try {
+		data = await request.json();
+	} catch (error) {
+		return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+	}
+
+	if (!data.password || typeof data.password !== 'string') {
+		return json({ error: 'Password must be a non-empty string' }, { status: 400 });
+	}
+
+	const result = login(data.password);
+	if (!result.success) {
+		return json({ error: 'Invalid password' }, { status: 401 });
+	}
+	return json({ token: result.token });
+};

--- a/src/routes/api/login/+server.ts
+++ b/src/routes/api/login/+server.ts
@@ -6,7 +6,8 @@ export const POST: RequestHandler = async ({ request }) => {
 	let data;
 	try {
 		data = await request.json();
-	} catch (error) {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	} catch (e) {
 		return json({ error: 'Invalid JSON in request body' }, { status: 400 });
 	}
 


### PR DESCRIPTION
We use JWTs as an elegant solution to not having a database. The auth scheme uses a simple site-wide password. 

This PR technically breaks the frontend. The frontend will be hooked up to this new auth scheme in a follow up.