### PR TITLE
Hook up frontend to authentication

### DIFF
--- a/src/lib/components/Login.svelte
+++ b/src/lib/components/Login.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import authState from '$lib/state/auth.svelte';
+	import { login } from '$lib/state/auth.svelte';
 
 	let password = '';
 </script>
@@ -9,7 +9,7 @@
 	<form
 		onsubmit={(event) => {
 			event.preventDefault();
-			authState.isAuthenticated = true;
+			login(password);
 		}}
 		class="flex flex-col space-y-3 sm:flex-row sm:space-y-0 sm:space-x-3"
 	>

--- a/src/lib/state/auth.svelte.ts
+++ b/src/lib/state/auth.svelte.ts
@@ -1,3 +1,5 @@
-const authState = $state({ isAuthenticated: false });
+import type { AuthState } from '$lib/types';
+
+const authState: AuthState = $state({ isAuthenticated: false, token: null });
 
 export default authState;

--- a/src/lib/state/auth.svelte.ts
+++ b/src/lib/state/auth.svelte.ts
@@ -2,4 +2,24 @@ import type { AuthState } from '$lib/types';
 
 const authState: AuthState = $state({ isAuthenticated: false, token: null });
 
+export async function login(password: string): Promise<void> {
+	const res = await fetch(`/api/login`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ password }),
+		signal: AbortSignal.timeout(5_000)
+	});
+	if (!res.ok) {
+		authState.isAuthenticated = false;
+		authState.token = null;
+		throw new Error(
+			res.status === 401 ? 'Invalid password' : `Login failed: ${res.status} ${res.statusText}`
+		);
+	}
+
+	const data = await res.json();
+	authState.token = data.token;
+	authState.isAuthenticated = true;
+}
+
 export default authState;

--- a/src/lib/state/travelTimes.svelte.ts
+++ b/src/lib/state/travelTimes.svelte.ts
@@ -1,14 +1,22 @@
 import type { TravelTimes, TravelTimesRequest } from '$lib/types';
+import authState from './auth.svelte';
 
 const travelTimesRequest: TravelTimesRequest = $state({ task: null });
 
 export async function getTravelTimes(streetAddress: string): Promise<TravelTimes> {
 	const params = new URLSearchParams({ 'street-address': streetAddress });
 	const res = await fetch(`/api/travel-times?${params}`, { signal: AbortSignal.timeout(30_000) });
-	if (!res.ok) {
-		throw new Error(`Failed to fetch travel times: ${res.status} ${res.statusText}`);
+	if (res.ok) return res.json() as Promise<TravelTimes>;
+
+	// The user should only have been able to submit the request if they were previously
+	// determined by the client to be authenticated. So, receiving a 401 most likely means that
+	// the JWT has expired.
+	if (res.status === 401) {
+		authState.isAuthenticated = false;
+		throw new Error(`Your session has expired. Please login.`);
 	}
-	return res.json() as Promise<TravelTimes>;
+
+	throw new Error(`Failed to fetch travel times: ${res.status} ${res.statusText}`);
 }
 
 export default travelTimesRequest;

--- a/src/lib/state/travelTimes.svelte.ts
+++ b/src/lib/state/travelTimes.svelte.ts
@@ -5,7 +5,10 @@ const travelTimesRequest: TravelTimesRequest = $state({ task: null });
 
 export async function getTravelTimes(streetAddress: string): Promise<TravelTimes> {
 	const params = new URLSearchParams({ 'street-address': streetAddress });
-	const res = await fetch(`/api/travel-times?${params}`, { signal: AbortSignal.timeout(30_000) });
+	const res = await fetch(`/api/travel-times?${params}`, {
+		headers: { Authorization: `Bearer ${authState.token}` },
+		signal: AbortSignal.timeout(30_000)
+	});
 	if (res.ok) return res.json() as Promise<TravelTimes>;
 
 	// The user should only have been able to submit the request if they were previously

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,13 @@ export interface TravelTimes {
 	};
 }
 
-export type TravelTimesRequest = { task: Promise<TravelTimes> | null };
+export interface TravelTimesRequest {
+	task: Promise<TravelTimes> | null;
+}
 
 export type GoalStatus = 'met' | 'partial' | 'unmet';
+
+export interface AuthState {
+	isAuthenticated: boolean;
+	token: string | null;
+}


### PR DESCRIPTION
You can now use the frontend again! The Login component will update authState (universal state), then the travel times request will use the saved token.

This handles when a token was set but 401ed, which usually means the token expired.

Follow-up improvements TODO:

* Add frontend for error and loading states
* Store in a cookie